### PR TITLE
Fix self-triggering effects in tabs and steps

### DIFF
--- a/src/components/compounds/Steps/StepItem.vue
+++ b/src/components/compounds/Steps/StepItem.vue
@@ -1,5 +1,5 @@
 <script>
-import { computed, ref, watchEffect } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { addToStore, useStore } from './Steps.vue'
 
 export default {
@@ -23,10 +23,9 @@ export default {
 
     addToStore({ ...props, id })
 
-    watchEffect(() => {
-      const index = tabs.value.tabs.findIndex(tab => tab.id === id)
+    watch(() => tabs.value.tabs.findIndex(tab => tab.id === id), (index) => {
       tabs.value.tabs.splice(index, 1, { id, ...props })
-    })
+    }, { immediate: true })
 
     const isActiveTab = computed(() => tabs.value.activeTab === id)
 

--- a/src/components/compounds/Tabs/Tab.vue
+++ b/src/components/compounds/Tabs/Tab.vue
@@ -1,5 +1,5 @@
 <script>
-import { computed, onMounted, onUpdated, ref, watchEffect } from 'vue'
+import { computed, onMounted, onUpdated, ref, watch } from 'vue'
 import { addToStore, useStore } from './Tabs.vue'
 
 export default {
@@ -38,10 +38,9 @@ export default {
 
     addToStore({ ...props, id })
 
-    watchEffect(() => {
-      const index = tabs.value.tabs.findIndex(tab => tab.id === id)
+    watch(() => tabs.value.tabs.findIndex(tab => tab.id === id), (index) => {
       tabs.value.tabs.splice(index, 1, { id, ...props })
-    })
+    }, { immediate: true })
 
     const isActiveTab = computed(() => tabs.value.activeTab === id)
 


### PR DESCRIPTION
the issue is with following:

```
watchEffect(() => {
  const index = tabs.value.tabs.findIndex(tab => tab.id === id)
  tabs.value.tabs.splice(index, 1, { id, ...props })
})
```

the callback will modify its dependency, effectively triggering itself